### PR TITLE
feat: add option to pass the stylua.toml location

### DIFF
--- a/doc/stylua.txt
+++ b/doc/stylua.txt
@@ -12,9 +12,22 @@ To find out more:
 https://github.com/wesleimp/stylua.nvim
 
 
-stylua.format({bufnr})                                           *stylua.format*
-    Format your Lua code. If {bufnr} is not set, the current buffer will be
+stylua.format({opts})                                           *stylua.format*
+    Format your Lua code. If {opts} is not set, some defaults will be
     used to format >
+
+    Parameters: ~
+        {opts} (table)  options to pass to the formatter
+
+    Options: ~
+        {bufnr}             (number)   specify the buffer number where
+                                       treesitter should run. (default:
+                                       current buffer)
+
+        {config_path}       (string)   specify the config file to use.
+                                       (default: .stylua.toml or
+                                       stylua.toml defined in the
+                                       project)
 
     :lua require("stylua").format()
 <

--- a/lua/stylua/init.lua
+++ b/lua/stylua/init.lua
@@ -38,9 +38,12 @@ local function find_stylua(path)
   return M._config[path]
 end
 
-function M.format(bufnr)
-  bufnr = bufnr or vim.api.nvim_get_current_buf()
-  local filepath = Path:new(vim.api.nvim_buf_get_name(bufnr)):absolute()
+function M.format(opts)
+  opts = opts or {}
+  local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
+  local toml_file = opts.toml_file and vim.api.nvim_buf_get_name(bufnr)
+
+  local filepath = Path:new(toml_file):absolute()
   local stylua_toml = find_stylua(filepath)
 
   local args = {}

--- a/lua/stylua/init.lua
+++ b/lua/stylua/init.lua
@@ -42,7 +42,7 @@ function M.format(opts)
   opts = opts or {}
   local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
 
-  local stylua_toml = ""
+  local stylua_toml
   if opts.config_path then
     stylua_toml = Path:new(opts.config_path):absolute()
   else

--- a/lua/stylua/init.lua
+++ b/lua/stylua/init.lua
@@ -41,10 +41,14 @@ end
 function M.format(opts)
   opts = opts or {}
   local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
-  local toml_file = opts.toml_file and vim.api.nvim_buf_get_name(bufnr)
 
-  local filepath = Path:new(toml_file):absolute()
-  local stylua_toml = find_stylua(filepath)
+  local stylua_toml = ""
+  if opts.config_path then
+    stylua_toml = Path:new(opts.config_path):absolute()
+  else
+    local filepath = Path:new(vim.api.nvim_buf_get_name(bufnr)):absolute()
+    stylua_toml = find_stylua(filepath)
+  end
 
   local args = {}
 


### PR DESCRIPTION
Closes #1 

Enable passing the config file path for formatting. eg

```lua
require("stylua").format({ config_path = "my_config.toml" })
```